### PR TITLE
Remove AttrDict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # User-specific stuff:
 .idea/*
+motd_venv/*
 
 ## File-based project format:
 *.iws

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-attrdict~=2.0.0
 requests~=2.20.0

--- a/saltbox-motd.py
+++ b/saltbox-motd.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
             exit(0)
 
     elif cmd_type == 'autoscan':
-        autoscan = utils.Autoscan(cfg.autoscan.url, cfg.autoscan.api_key)
+        autoscan = utils.Autoscan(cfg["autoscan"]["url"], cfg["autoscan"]["api_key"])
 
         # Process funcs
         if cmd_func == 'get_queue_count':
@@ -76,7 +76,7 @@ if __name__ == "__main__":
             exit(0)
 
     elif cmd_type == 'rtorrent':
-        rtorrent = utils.Rtorrent(cfg.rtorrent.url)
+        rtorrent = utils.Rtorrent(cfg["rtorrent"]["url"])
 
         # Process funcs
         if cmd_func == 'get_download_total':
@@ -97,7 +97,7 @@ if __name__ == "__main__":
             exit(0)
 
     elif cmd_type == 'nzbget':
-        nzbget = utils.Nzbget(cfg.nzbget.url)
+        nzbget = utils.Nzbget(cfg["nzbget"]["url"])
 
         # Process funcs
         if cmd_func == "get_download_total":
@@ -114,7 +114,7 @@ if __name__ == "__main__":
             exit(0)
 
     elif cmd_type == 'tautulli':
-        tautulli = utils.Tautulli(cfg.tautulli.url, cfg.tautulli.api_key)
+        tautulli = utils.Tautulli(cfg["tautulli"]["url"], cfg["tautulli"]["api_key"])
 
         # Process funcs
         if cmd_func == "get_stream_bandwidth":

--- a/utils/config.py
+++ b/utils/config.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-from attrdict import AttrDict
+# from attrdict import AttrDict
 
 
 class Singleton(type):
@@ -13,24 +13,6 @@ class Singleton(type):
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
 
         return cls._instances[cls]
-
-
-class AttrConfig(AttrDict):
-    """
-    Simple AttrDict subclass to return None when requested attribute does not exist
-    """
-
-    def __init__(self, config):
-        super().__init__(config)
-
-    def __getattr__(self, item):
-        try:
-            return super().__getattr__(item)
-        except AttributeError:
-            pass
-        # Default behaviour
-        return None
-
 
 class Config(object, metaclass=Singleton):
     base_config = {
@@ -110,7 +92,7 @@ class Config(object, metaclass=Singleton):
 
     def load_config(self):
         with open(self.config_path, 'r') as fp:
-            return AttrConfig(json.load(fp))
+            return json.load(fp)
 
     def upgrade_settings(self, currents):
         upgraded = False
@@ -144,4 +126,4 @@ class Config(object, metaclass=Singleton):
             return merged, sub_upgraded
 
         upgraded_settings, upgraded = inner_upgrade(self.base_config, currents)
-        return AttrConfig(upgraded_settings), upgraded
+        return upgraded_settings, upgraded

--- a/utils/config.py
+++ b/utils/config.py
@@ -2,9 +2,6 @@ import json
 import os
 import sys
 
-# from attrdict import AttrDict
-
-
 class Singleton(type):
     _instances = {}
 


### PR DESCRIPTION
Removes the AttrDict dependency and uses a Plain Old Dict.

Ran dependencies, preinstall, and `sb install motd` on a brand new Ubuntu 22.04 machine.  MOTD displayed as expected:

![image](https://user-images.githubusercontent.com/3865541/166408892-a6eb22ed-d583-41e0-a726-177ef3b1a0f0.png)
